### PR TITLE
correctly setting parameters for action creator

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -1,6 +1,6 @@
 export const TOGGLE_MENU = 'TOGGLE_MENU';
 
-const toggleMenu = (isOpen = false, menuId) => {
+const toggleMenu = ({ isOpen = false, menuId }) => {
   return {
     type: TOGGLE_MENU,
     payload: menuId ? { isOpen, menuId } : { isOpen }


### PR DESCRIPTION
Hi! Thanks for your awesome work on this plugin.

I was hitting a strange error when following your docs for the action creator, and I noticed there was a tiny error in the action creator itself.

I think this creator was meant to accept and options object, but as written, it was accepting a pair of values. Let me know if this looks good! Thanks for all your work on this, amazing stuff.